### PR TITLE
A small fix about the compilation order in build.sh.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -23,7 +23,6 @@ else
     framework/fun4all
     interface_main
     online/chan_map
-    online/onlmonserver
     online/decoder_maindaq
     packages/Half
     packages/vararray
@@ -45,6 +44,7 @@ else
     packages/PHGenFitPkg/PHGenFit
     packages/ktracker
     packages/embedding
+    online/onlmonserver
     module_example
 	)
 fi


### PR DESCRIPTION
I'm glad to see the online-monitor plots on the reconstructed variables.  This pull request is just to fix a minor thing, namely "online/onlmonserver" has to be build after "package/ktracker" in "build.sh" because of the new dependency.  With this fix, I succeeded at compiling the whole codes on seaquestdaq01.

I was not able to run [Fun4MainDaq.C](https://github.com/E1039-Collaboration/e1039-analysis/blob/master/OnlMonDev/Fun4MainDaq.C) due to the following error, probably because my kTracker setting (like KTRACKER_ROOT) was not complete.  It is not urgent but better for us to include a reasonable setting in e906-core itself (via setup-e1039-core.sh) soon.
> Integer Flags:
> terminate called after throwing an instance of 'std::logic_error'
>  what():  basic_string::_S_construct null not valid

It was a silly bug that the refresh of "m_list_obj" was commented out.  I must have commented out that of "m_list_h1".   As "m_list_h1" is obsolete, I will delete it soon.

Thank you so much for the massive changes on CMakeFiles.